### PR TITLE
Add discovery support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.3.0...HEAD
+
+## [0.3.0][]
+
+[0.3.0]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.2.1...0.3.0
+
+### Added
+
+-   discovery support [#4][4]
+
+[4]: https://github.com/chaostoolkit-incubator/chaostoolkit-cloud-foundry/issues/4
 
 ## [0.2.1][]
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ That's it!
 
 Please explore the code to see existing probes and actions.
 
+### Discovery
+
+You may use the Chaos Toolkit to discover the capabilities of this extension:
+
+```
+$ chaos discover chaostoolkit-cloud-foundry --no-install
+```
+
+If you have logged in against a Cloud Foundry environment, this will discover
+information about it along the way.
+
 ## Configuration
 
 This extension to the Chaos Toolkit need credentials to a Cloud Foundry account

--- a/chaoscf/__init__.py
+++ b/chaoscf/__init__.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
-from typing import Any, Dict
+import json
+import os
+import os.path
+from typing import Any, Dict, List
 
+from chaoslib.discovery.discover import discover_actions, discover_probes, \
+    initialize_discovery_result
 from chaoslib.exceptions import FailedActivity
-from chaoslib.types import Configuration, Secrets
+from chaoslib.types import Configuration, Discovery, DiscoveredActivities, \
+    DiscoveredSystemInfo, Secrets
 from logzero import logger
 from oauthlib.oauth2 import LegacyApplicationClient
 from oauthlib.oauth2.rfc6749.errors import OAuth2Error
@@ -12,8 +18,8 @@ import urllib3
 
 urllib3.disable_warnings()
 
-__version__ = '0.2.1'
-__all__ = ["__version__", "auth"]
+__version__ = '0.3.0'
+__all__ = ["__version__", "auth", "discover"]
 
 
 def auth(configuration: Configuration, secrets: Secrets) -> Dict[str, str]:
@@ -36,6 +42,7 @@ def auth(configuration: Configuration, secrets: Secrets) -> Dict[str, str]:
     Returns a mapping with the `access_token` and `refresh_token` keys as per
     http://docs.cloudfoundry.org/api/uaa/version/4.8.0/index.html#password-grant
     """
+
     api_url = configuration.get("cf_api_url")
     verify_ssl = configuration.get("cf_verify_ssl", True)
 
@@ -44,6 +51,8 @@ def auth(configuration: Configuration, secrets: Secrets) -> Dict[str, str]:
     client_id = secrets.get("cf_client_id", "cf")
     client_secret = secrets.get("cf_client_secret", "")
 
+    logger.debug(
+        "Querying a new access token for client '{c}'".format(c=client_id))
     return get_tokens(api_url, username, password, client_id, client_secret,
                       verify_ssl)
 
@@ -78,3 +87,71 @@ def get_tokens(api_url: str, username: str, password: str,
                              "cannot proceed further")
 
     return r
+
+
+def discover(discover_system: bool = True) -> Discovery:
+    """
+    Discover Cloud Foundry capabilities from this extension as well, some
+    information about the Cloud Foundry cluster.
+    """
+    logger.info("Discovering capabilities from chaostoolkit-cloud-foundry")
+
+    discovery = initialize_discovery_result(
+        "chaostoolkit-cloud-foundry", __version__, "cloud-foundry")
+    discovery["activities"].extend(load_exported_activities())
+    if discover_system:
+        discovery["system"] = explore_cf_system()
+
+    return discovery
+
+
+###############################################################################
+# Private functions
+###############################################################################
+def load_exported_activities() -> List[DiscoveredActivities]:
+    """
+    Extract metadata from actions and probes exposed by this extension.
+    """
+    activities = []
+    activities.extend(discover_actions("chaoscf.actions"))
+    activities.extend(discover_probes("chaoscf.probes"))
+    return activities
+
+
+def explore_cf_system() -> DiscoveredSystemInfo:
+    """
+    Fetch information from the current Cloud Foundry context.
+    """
+    # importing here to avoid circular reference
+    from chaoscf.api import call_api
+
+    logger.info("Discovering Cloud Foundry system")
+    cf_local_config = os.path.expanduser("~/.cf/config.json")
+    if not os.path.exists(cf_local_config):
+        logger.warn(
+            "Could not locate a cloud coundry config file at '{s}'".format(
+                s=cf_local_config))
+        return
+
+    configuration = {}
+    with open(cf_local_config) as f:
+        cf_conf = json.loads(f.read())
+        if "AccessToken" not in cf_conf:
+            logger.warn(
+                "'{s}' is missing an access token, please run `cf login` "
+                "and re-run the discovery command".format(
+                    s=cf_local_config))
+            return
+
+        token_type, token = cf_conf["AccessToken"].split(" ", 1)
+        configuration["cf_token_type"] = token_type
+        configuration["cf_access_token"] = token
+        configuration["cf_verify_ssl"] = not cf_conf["SSLDisabled"]
+        configuration["cf_api_url"] = cf_conf["Target"]
+
+    info = {}
+    info["orgs"] = call_api("/v2/organizations", configuration).json()
+    info["apps"] = call_api("/v2/apps", configuration).json()
+    info["routes"] = call_api("/v2/routes", configuration).json()
+
+    return info

--- a/chaoscf/api.py
+++ b/chaoscf/api.py
@@ -14,14 +14,20 @@ __all__ = ['call_api', 'get_app_by_name', 'get_org_by_name',
 
 
 def call_api(path: str, configuration: Configuration,
-             secrets: Secrets, query: Dict[str, Any] = None,
+             secrets: Secrets = None, query: Dict[str, Any] = None,
              data: Dict[str, Any] = None, method: str = "GET",
              headers: Dict[str, str] = None) -> requests.Response:
     """
     Perform a Cloud Foundry API call and return the full response to the
     caller.
     """
-    tokens = auth(configuration, secrets)
+    if "cf_access_token" not in configuration:
+        tokens = auth(configuration, secrets)
+    else:
+        tokens = {
+            "token_type": configuration.get("cf_token_type", "bearer"),
+            "access_token": configuration.get("cf_access_token")
+        }
 
     h = {
         "Accept": "application/json",

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from chaoscf import __version__, discover
+
+
+def test_discover_extension_capabilities():
+    discovery = discover(discover_system=False)
+    assert discovery["extension"]["name"] == "chaostoolkit-cloud-foundry"
+    assert discovery["extension"]["version"] == __version__
+    assert len(discovery["activities"]) > 0


### PR DESCRIPTION
Closes #4

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>

This will discover apps, routes and orgs for now. We could definitely fetch more information, please comment on which ones as I'm not too sure yet :)

https://apidocs.cloudfoundry.org/280/ (all `List...` calls could be candidates)