### PR TITLE
Feature: Add stop application action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.5.1...HEAD
 
+### Changed
+
+-   Add "Stop CF application" action
+
 ## [0.5.1][]
 
 [0.5.1]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.5.0...0.5.1

--- a/chaoscf/actions.py
+++ b/chaoscf/actions.py
@@ -2,7 +2,6 @@
 import random
 from typing import Any, Dict, List
 
-from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
@@ -11,7 +10,7 @@ from chaoscf.api import call_api, get_app_by_name, get_app_routes_by_host, \
 
 __all__ = ["delete_app", "remove_routes_from_app", "terminate_app_instance",
            "terminate_some_random_instance", "unbind_service_from_app",
-           "unmap_route_from_app", "map_route_to_app"]
+           "unmap_route_from_app", "map_route_to_app", "stop_app"]
 
 
 def delete_app(app_name: str, configuration: Configuration, secrets: Secrets,
@@ -27,6 +26,22 @@ def delete_app(app_name: str, configuration: Configuration, secrets: Secrets,
 
     path = "/v2/apps/{a}".format(a=app['metadata']['guid'])
     call_api(path, configuration, secrets, method="DELETE")
+
+
+def stop_app(app_name: str, configuration: Configuration, secrets: Secrets,
+             org_name: str = None, space_name: str = None):
+    """
+    Stop application
+
+    See https://apidocs.cloudfoundry.org/280/apps/updating_an_app.html
+    """
+    app = get_app_by_name(
+        app_name, configuration, secrets, org_name=org_name,
+        space_name=space_name)
+
+    path = "/v2/apps/{a}".format(a=app['metadata']['guid'])
+    call_api(
+        path, configuration, secrets, method="PUT", body={"state": "STOPPED"})
 
 
 def remove_routes_from_app(app_name: str, route_host: str,

--- a/chaoscf/api.py
+++ b/chaoscf/api.py
@@ -15,7 +15,7 @@ __all__ = ['call_api', 'get_app_by_name', 'get_org_by_name',
 
 def call_api(path: str, configuration: Configuration,
              secrets: Secrets, query: Dict[str, Any] = None,
-             data: Dict[str, Any] = None, method: str = "GET",
+             body: Dict[str, Any] = None, method: str = "GET",
              headers: Dict[str, str] = None) -> requests.Response:
     """
     Perform a Cloud Foundry API call and return the full response to the
@@ -41,7 +41,7 @@ def call_api(path: str, configuration: Configuration,
     verify_ssl = configuration.get("cf_verify_ssl", True)
     url = "{u}{p}".format(u=configuration["cf_api_url"], p=path)
     r = requests.request(
-        method, url, params=query, data=data, verify=verify_ssl, headers=h)
+        method, url, params=query, json=body, verify=verify_ssl, headers=h)
 
     request_id = r.headers.get("X-VCAP-Request-ID")
     logger.debug("Request ID: {i}".format(i=request_id))

--- a/examples/stop_application.py
+++ b/examples/stop_application.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import argparse
+
+from connection import create_connection_config
+
+from chaoscf.actions import stop_app
+
+
+def cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--app', dest='app_name', help='application name')
+    parser.add_argument('--org', dest='org_name', help='org name')
+    parser.add_argument('--space', dest='space_name', help='space name')
+    return parser.parse_args()
+
+
+def run(app_name: str, org_name: str = None,
+        space_name: str = None):
+    """
+    Stop a given application. The org and space are not required arguments.
+    """
+    config, secrets = create_connection_config()
+    stop_app(app_name, configuration=config, secrets=secrets, org_name=org_name, space_name=space_name)
+
+
+if __name__ == '__main__':
+    args = cli()
+    run(args.app_name, args.org_name, args.space_name)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,29 +1,38 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from chaoscf.actions import delete_app, terminate_app_instance, \
-    terminate_some_random_instance, unbind_service_from_app, \
-    unmap_route_from_app, map_route_to_app
-from chaoslib.exceptions import FailedActivity
 import pytest
 import requests_mock
+from chaoslib.exceptions import FailedActivity
 
+import chaoscf
+from chaoscf.actions import delete_app, terminate_app_instance, \
+    terminate_some_random_instance, unbind_service_from_app, \
+    unmap_route_from_app, map_route_to_app, stop_app
 from fixtures import config, responses, secrets
 
 
+def test_all_lists_the_actions_exposed():
+    assert ["delete_app", "remove_routes_from_app", "terminate_app_instance",
+            "terminate_some_random_instance", "unbind_service_from_app",
+            "unmap_route_from_app", "map_route_to_app", "stop_app"] == chaoscf.actions.__all__
+
+
+@patch('chaoscf.actions.get_app_by_name', autospec=True)
 @patch('chaoscf.actions.call_api', autospec=True)
-def test_fail_to_delete_unknown_app(call_api):
+def test_fail_to_delete_unknown_app(call_api, get_app_by_name):
     apps = responses.apps.copy()
+    apps['total_results'] = 0
     apps['resources'] = []
 
-    # first call from get_app_by_name, second from delete_app
-    call_api.return_value = [
-        responses.FakeResponse(status_code=200, json = lambda: apps),
-        responses.FakeResponse(status_code=200)
-    ]
+    app_name = "my-app"
+    get_app_by_name.side_effect = FailedActivity("app '{a}' was not found".format(a=app_name))
+    call_api.return_value = responses.FakeResponse(status_code=200)
 
-    with pytest.raises(FailedActivity) as ex:
-        delete_app("my-app", config.config, secrets.secrets)
+    with pytest.raises(FailedActivity) as exception:
+        delete_app(app_name, config.config, secrets.secrets)
+
+    assert "app 'my-app' was not found" in str(exception)
 
 
 @patch('chaoscf.actions.get_app_by_name', autospec=True)
@@ -106,7 +115,7 @@ def test_unmap_route_from_app(auth):
     app_guid = responses.app["metadata"]["guid"]
     with requests_mock.mock() as m:
         m.get(
-            "https://example.com/v2/apps?q=name:my-app", 
+            "https://example.com/v2/apps?q=name:my-app",
             status_code=200,
             json=responses.apps, complete_qs=True)
 
@@ -130,7 +139,7 @@ def test_map_route_to_app(auth):
     app_guid = responses.app["metadata"]["guid"]
     with requests_mock.mock() as m:
         m.get(
-            "https://example.com/v2/apps?q=name:my-app", 
+            "https://example.com/v2/apps?q=name:my-app",
             status_code=200,
             json=responses.apps, complete_qs=True)
 
@@ -143,7 +152,22 @@ def test_map_route_to_app(auth):
         m.put(
             "https://example.com/v2/apps/{app}/routes/{s}".format(
                 app=app_guid, s=route_guid), status_code=201,
-                json=responses.route)
+            json=responses.route)
 
         map_route_to_app(
             "my-app", "whatever", config.config, secrets.secrets)
+
+
+@patch('chaoscf.actions.get_app_by_name', autospec=True)
+@patch('chaoscf.api.auth', autospec=True)
+def test_stop_app(auth, get_app_by_name):
+    auth.return_value = responses.auth_response
+    app = responses.app
+    get_app_by_name.return_value = app
+    with requests_mock.mock() as mock:
+        update_url = "https://example.com/v2/apps/%s" % app["metadata"]["guid"]
+        mock.put(update_url, status_code=201, json=app)
+
+        stop_app("my-app", config.config, secrets.secrets)
+
+    assert mock.call_count == 1


### PR DESCRIPTION
The pull request adds stop_app action to the existing actions.

I have two additional changes:
* The `test_fail_to_delete_unknown_app` test was failing and I made a minor tweak to fix it
* I have changes `call_api` parameter `data` to `body` as `data` in requests assumes content type to be `application/x-www-form-urlencoded` whereas cf api supports `application/json`