### PR TITLE
Fixes fetch bind to match CF API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.7.0...HEAD
 
+### Changed
+
+ - Fixed "get_bind_by_name" to use the CF API specs
+
 ## [0.7.0][]
 
 [0.7.0]: https://github.com/chaostoolkit/chaostoolkit-cloud-foundry/compare/0.6.0...0.7.0

--- a/chaoscf/actions.py
+++ b/chaoscf/actions.py
@@ -228,13 +228,9 @@ def unbind_service_from_app(app_name: str, bind_name: str,
     See
     https://apidocs.cloudfoundry.org/280/service_bindings/delete_a_particular_service_binding.html
     """  # noqa: E501
-    app = get_app_by_name(
-        app_name, configuration, secrets, org_name=org_name,
-        space_name=space_name)
-
     service_bind = get_bind_by_name(
-        bind_name, configuration, secrets, org_name=org_name,
-        space_name=space_name)
+        bind_name, configuration, secrets,
+        app_name=app_name, space_name=space_name, org_name=org_name)
 
     logger.debug("Ubinding service {s} from application {a}".format(
         s=bind_name, a=app_name))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -99,7 +99,7 @@ def test_unbind_service_from_app(auth):
             json=responses.apps, complete_qs=True)
 
         m.get(
-            "https://example.com/v2/service_bindings?q=name:my-bind",
+            "https://example.com/v2/apps/" + responses.app["metadata"]["guid"] + "/service_bindings",
             status_code=200, json=responses.binds, complete_qs=True)
 
         m.delete(


### PR DESCRIPTION
The old code used to search with org_guid and service binding name which are not valid query parameters supported by CF API (any version)
See https://apidocs.cloudfoundry.org/280/apps/list_all_service_bindings_for_the_app.html

There is no CF API which allows fetching service bindings based on bind name hence I have changed the code to fetch app service bindings and then filter in-code based on bind name

Signed-off-by: Garima Singh <igarimasingh@gmail.com>